### PR TITLE
Make the boolean parameter on toggle optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ collapsible.init();
 
 You can see the above in action in [the included example file](./example/index.html).
 
-Collapsible regions can be shown and hidden programatically using the `toggle()` method, which accepts a boolean `true` or `false`:
+Collapsible regions can be shown and hidden programatically using the `toggle()` method, which accepts an optional boolean `true` or `false`:
 
 ```js
 collapsible.toggle(true);

--- a/dist/aria-collapsible.js
+++ b/dist/aria-collapsible.js
@@ -1,5 +1,5 @@
 /*!
- *  aria-collapsible 2.0.1
+ *  aria-collapsible 2.1.0
  *
  *  A lightweight, dependency-free JavaScript module for generating progressively-enhanced collapsible regions using ARIA States and Properties.
  *
@@ -26,9 +26,10 @@
     }
     var handleClick = function(event) {
       event.preventDefault();
-      toggle($control.getAttribute("aria-expanded") !== "true");
+      toggle();
     };
     var toggle = function(value) {
+      if (value == null) value = $control.getAttribute("aria-expanded") !== "true";
       $control.setAttribute("aria-expanded", value);
       $region[!value ? "setAttribute" : "removeAttribute"]("aria-hidden", true);
       if (value) {

--- a/dist/aria-collapsible.min.js
+++ b/dist/aria-collapsible.min.js
@@ -1,5 +1,5 @@
 /*!
- *  aria-collapsible 2.0.1
+ *  aria-collapsible 2.1.0
  *
  *  A lightweight, dependency-free JavaScript module for generating progressively-enhanced collapsible regions using ARIA States and Properties.
  *
@@ -10,4 +10,4 @@
  *  aria-collapsible may be freely distributed under the MIT license.
  */
 
-!function(t,e){"function"==typeof define&&define.amd?define([],e):"object"==typeof exports?module.exports=e():t.Collapsible=e()}(this,function(){"use strict";return function(t){if(t)var e=document.getElementById(t.getAttribute("aria-controls"));var i=function(e){e.preventDefault(),n("true"!==t.getAttribute("aria-expanded"))},n=function(i){t.setAttribute("aria-expanded",i),e[i?"removeAttribute":"setAttribute"]("aria-hidden",!0),i&&e.focus()};return{init:function(){e&&(t.setAttribute("aria-expanded",!1),t.removeAttribute("aria-hidden"),e.setAttribute("aria-hidden",!0),e.setAttribute("tabindex",-1),t.addEventListener("click",i),this.toggle=n)}}}});
+!function(t,e){"function"==typeof define&&define.amd?define([],e):"object"==typeof exports?module.exports=e():t.Collapsible=e()}(this,function(){"use strict";return function(t){if(t)var e=document.getElementById(t.getAttribute("aria-controls"));var i=function(t){t.preventDefault(),n()},n=function(i){null==i&&(i="true"!==t.getAttribute("aria-expanded")),t.setAttribute("aria-expanded",i),e[i?"removeAttribute":"setAttribute"]("aria-hidden",!0),i&&e.focus()};return{init:function(){e&&(t.setAttribute("aria-expanded",!1),t.removeAttribute("aria-hidden"),e.setAttribute("aria-hidden",!0),e.setAttribute("tabindex",-1),t.addEventListener("click",i),this.toggle=n)}}}});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aria-collapsible",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A lightweight, dependency-free JavaScript module for generating progressively-enhanced collapsible regions using ARIA States and Properties.",
   "main": "dist/aria-collapsible.js",
   "scripts": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -15,7 +15,7 @@ var colors = require('colors'),
 		' *  ' + pkg.name + ' may be freely distributed under the MIT license.\n' +
 		' */\n';
 
-exec('uglifyjs src/aria-collapsible.js --beautify "indent-level=2" --preamble "' + preamble + '" --output dist/aria-collapsible.js');
-exec('uglifyjs src/aria-collapsible.js --compress --mangle --preamble "' + preamble + '" --output dist/aria-collapsible.min.js');
+exec('$(npm bin)/uglifyjs src/aria-collapsible.js --beautify "indent-level=2" --preamble "' + preamble + '" --output dist/aria-collapsible.js');
+exec('$(npm bin)/uglifyjs src/aria-collapsible.js --compress --mangle --preamble "' + preamble + '" --output dist/aria-collapsible.min.js');
 
 console.log(colors.green('aria-collapsible %s built successfully!'), pkg.version);

--- a/src/aria-collapsible.js
+++ b/src/aria-collapsible.js
@@ -17,10 +17,12 @@
 		var handleClick = function(event) {
 			event.preventDefault();
 
-			toggle($control.getAttribute('aria-expanded') !== 'true');
+			toggle();
 		};
 
 		var toggle = function(value) {
+			if (value == null) value = $control.getAttribute('aria-expanded') !== 'true';
+
 			$control.setAttribute('aria-expanded', value);
 			$region[!value ? 'setAttribute' : 'removeAttribute']('aria-hidden', true);
 


### PR DESCRIPTION
This basically emulates how jQuery’s `toggle` method works: when no boolean is supplied the Collapsible will toggle to whatever state it isn’t currently in.

Almost no code is added as the boolean definition is lifted entirely out of `handleClick`.

There is a separate commit fixing the build script for those of us that do not have UglifyJS installed globally. This should probably have been an entirely separate PR but I wasn’t thinking about that when toying with the toggle change.
